### PR TITLE
fix index out of range taking &b[0]

### DIFF
--- a/sys_linux.go
+++ b/sys_linux.go
@@ -142,11 +142,11 @@ func parseInfo(b []byte) (tcpopt.Option, error) {
 }
 
 func parseCCAlgorithmInfo(name string, b []byte) (CCAlgorithmInfo, error) {
-	pt := unsafe.Pointer(&b[0])
 	if strings.HasPrefix(name, "dctcp") {
 		if len(b) < sizeofTCPDCTCPInfo {
 			return nil, errors.New("short buffer")
 		}
+		pt := unsafe.Pointer(&b[0])
 		sdi := (*tcpDCTCPInfo)(pt)
 		di := &DCTCPInfo{Alpha: uint(sdi.Alpha)}
 		if sdi.Enabled != 0 {
@@ -158,6 +158,7 @@ func parseCCAlgorithmInfo(name string, b []byte) (CCAlgorithmInfo, error) {
 		if len(b) < sizeofTCPBBRInfo {
 			return nil, errors.New("short buffer")
 		}
+		pt := unsafe.Pointer(&b[0])
 		sdi := (*tcpBBRInfo)(pt)
 		di := &BBRInfo{
 			EstBandwidth: uint(sdi.BandwidthHi)<<8 + uint(sdi.BandwidthLo),
@@ -170,6 +171,7 @@ func parseCCAlgorithmInfo(name string, b []byte) (CCAlgorithmInfo, error) {
 	if len(b) < sizeofTCPVegasInfo {
 		return nil, errors.New("short buffer")
 	}
+	pt := unsafe.Pointer(&b[0])
 	svi := (*tcpVegasInfo)(pt)
 	vi := &VegasInfo{
 		RoundTrips: uint(svi.Rttcnt),


### PR DESCRIPTION
Fix https://github.com/getlantern/http-proxy-lantern/issues/181, which was a silly bug I brought in at https://github.com/getlantern/tcpinfo/pull/1.